### PR TITLE
Restrict metomic to at most 15 minutes of runtime

### DIFF
--- a/workflows/metomic.yml
+++ b/workflows/metomic.yml
@@ -11,6 +11,7 @@ jobs:
     continue-on-error: true
     name: Scan For Secrets
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
 
       - name: checkout-repo


### PR DESCRIPTION
We are seeing very large runtimes at random (30min - 6h) which aren't finishing. Capping the runtime at 15 minutes should cancel them earlier, free up some workers and also cut down on wasted spending.