### PR TITLE
Add fetch-depth parameter to checkout-repo step

### DIFF
--- a/workflows/metomic.yml
+++ b/workflows/metomic.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: authenticate-with-metomic
         id: authenticate


### PR DESCRIPTION
Prior to this change the `checkout-repo` step caused long scan times.

Following a recommendation from Metomic, adding 'fetch-depth: 0' will prevent this from happening.